### PR TITLE
Add 'now' context to portal and policy pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -294,11 +294,13 @@ create_sample_content()
 
 @app.route('/privacy-policy')
 def privacy_policy():
-    return render_template('privacy_policy.html')
+    now = datetime.datetime.now()
+    return render_template('privacy_policy.html', now=now)
 
 @app.route('/terms-of-service')
 def terms_of_service():
-    return render_template('terms_of_service.html')
+    now = datetime.datetime.now()
+    return render_template('terms_of_service.html', now=now)
 
 @app.route('/consulting')
 def consulting_services():
@@ -359,27 +361,32 @@ def logout():
 @requires_auth
 def customer_portal():
     user = session.get('user')
+    now = datetime.datetime.now()
     return render_template('customer_portal.html',
                          user=user,
+                         now=now,
                          version="2.0.0")  # Hardcoded version for development
 
 @app.route('/portal/profile')
 @requires_auth
 def customer_profile():
     user = session.get('user')
-    return render_template('customer_profile.html', user=user)
+    now = datetime.datetime.now()
+    return render_template('customer_profile.html', user=user, now=now)
 
 @app.route('/portal/resources')
 @requires_auth
 def customer_resources():
     user = session.get('user')
-    return render_template('customer_resources.html', user=user)
+    now = datetime.datetime.now()
+    return render_template('customer_resources.html', user=user, now=now)
 
 @app.route('/portal/support')
 @requires_auth
 def customer_support():
     user = session.get('user')
-    return render_template('customer_support.html', user=user)
+    now = datetime.datetime.now()
+    return render_template('customer_support.html', user=user, now=now)
 
 # This is required for Azure App Service to find the application
 application = app


### PR DESCRIPTION
## Summary
- pass the current time to portal-related templates
- include `now` in privacy and terms pages

## Testing
- `pip install -q -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: command not found)*